### PR TITLE
RAD-4289 - Update semver version from 5.7.1 to 5.7.2, and 6.3.0 to 6.3.1 for MangoAutomation (ma-dashboards)

### DIFF
--- a/UI/RELEASE-NOTES
+++ b/UI/RELEASE-NOTES
@@ -1,3 +1,6 @@
+*Version 4.5.4*
+* Upgrade semver version from 5.7.1 to 5.7.2 and 6.3.0 to 6.3.1
+
 *Version 4.5.3*
 * Update jszip to v3.10.1
 * Fixed the issue where published points table was affecting publisher edit form state

--- a/UI/yarn.lock
+++ b/UI/yarn.lock
@@ -7314,9 +7314,9 @@ seedrandom@^3.0.5:
   integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0, semver@^5.7.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^4.1.0:
   version "4.3.6"


### PR DESCRIPTION
Update semver version from 5.7.1 to 5.7.2, and 6.3.0 to 6.3.1 for MangoAutomation (ma-dashboards)

## Description

https://radixiot.atlassian.net/browse/RAD-4289
Update the version for Semver used in the mangoAutomation, from 5.7.1 to 5.7.2 and 6.3.0 to 6.3.1, this needs to be done in all the modules and references to this package



## Release Notes

Did you update the release notes?
Yes